### PR TITLE
add default manifest for cloudfoundry hosting

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,5 @@
+---
+applications:
+- name: loremipsum
+  memory: 64M
+  buildpack: staticfile_buildpack


### PR DESCRIPTION
Cloudfoundry supports a [static_buildpack](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html) to host static content

The manifest makes hosting as simple as

```
cf push
```